### PR TITLE
Fix variable name typo for diarization model

### DIFF
--- a/chatbot/modules/resumer_audition.py
+++ b/chatbot/modules/resumer_audition.py
@@ -12,7 +12,7 @@ audio = whisperx.load_audio(video_path)
 result = model.transcribe(audio)
 
 # Étape 2 : Diarisation
-diaraize_model = whisperx.DiarizationPipeline(use_auth_token=None)
+diarize_model = whisperx.DiarizationPipeline(use_auth_token=None)
 segments = diarize_model(audio, min_speakers=2, max_speakers=6)
 
 # Combine transcription et diarisation


### PR DESCRIPTION
## Summary
- correct variable name `diaraize_model` -> `diarize_model` in `resumer_audition.py`

## Testing
- `python3 -m py_compile chatbot/modules/resumer_audition.py`
