### PR TITLE
Fix 0-based column index in DT cell edit handlers

### DIFF
--- a/chatbot/helpers/autocompletion_helper.R
+++ b/chatbot/helpers/autocompletion_helper.R
@@ -69,7 +69,7 @@ setupBudgetExtraction <- function(input, output, session,
       observeEvent(input$budget_table_mapping_cell_edit, {
         info <- input$budget_table_mapping_cell_edit
         df <- donnees_extraites()
-        df[info$row, info$col] <- DT::coerceValue(info$value, df[info$row, info$col])
+        df[info$row, info$col + 1] <- DT::coerceValue(info$value, df[info$row, info$col + 1])
         donnees_extraites(df)
       })
       

--- a/chatbot/modules/autocompletion.R
+++ b/chatbot/modules/autocompletion.R
@@ -42,7 +42,7 @@ mod_budget_mapping_server <- function(id, mapping_data, tags_json) {
     observeEvent(input$mapping_table_cell_edit, {
       info <- input$mapping_table_cell_edit
       df   <- mapping_data()
-      df[info$row, info$col] <- DT::coerceValue(info$value, df[info$row, info$col])
+      df[info$row, info$col + 1] <- DT::coerceValue(info$value, df[info$row, info$col + 1])
       mapping_data(df)
     })
     

--- a/chatbot/modules/autocompletion2.R
+++ b/chatbot/modules/autocompletion2.R
@@ -37,7 +37,7 @@ mod_budget_mapping_server <- function(id, mapping_data, tags_json) {
     observeEvent(input$mapping_table_cell_edit, {
       info <- input$mapping_table_cell_edit
       df   <- mapping_data()
-      df[info$row, info$col] <- DT::coerceValue(info$value, df[info$row, info$col])
+      df[info$row, info$col + 1] <- DT::coerceValue(info$value, df[info$row, info$col + 1])
       mapping_data(df)
     })
     

--- a/chatbot/server_chatbot2.R
+++ b/chatbot/server_chatbot2.R
@@ -97,8 +97,8 @@ server <- function(input, output, session) {
   observeEvent(input$budget_table_cell_edit, {
     info <- input$budget_table_cell_edit
     df   <- budget_data()
-    df[info$row, info$col] <- DT::coerceValue(
-      info$value, df[info$row, info$col]
+    df[info$row, info$col + 1] <- DT::coerceValue(
+      info$value, df[info$row, info$col + 1]
     )
     donnees_extraites(df)
     log_debug("Cellule modifiée ligne={info$row}, col={info$col}")


### PR DESCRIPTION
## Summary
- correct DataTable cell edit indices in helper and modules
- adjust server logic for edited budget tables

## Testing
- `git status --short`