### PR TITLE
Fix parseur excel integration

### DIFF
--- a/chatbot/dependencies.R
+++ b/chatbot/dependencies.R
@@ -35,9 +35,11 @@ required_packages <- c(
   "rhandsontable", 
   "reactable", 
   "shinycssloaders", 
-  "openxlsx2", 
-  "tidyxl", 
-  "openxlsx"
+  "openxlsx2",
+  "tidyxl",
+  "openxlsx",
+  "stringr",
+  "dplyr"
 )
 
 # Install missing R packages

--- a/chatbot/modules/parseur_excel/excel_formula_to_R.R
+++ b/chatbot/modules/parseur_excel/excel_formula_to_R.R
@@ -3,6 +3,10 @@
 # Convertisseur de formules Excel en code R
 # Architecture : nettoyage → split générique (multi-char ops) → parsing récursif → codegen via table de fonctions
 
+# Packages -------------------------------------------------------------------
+# stringr est requis pour toutes les fonctions str_* utilisées dans ce module
+library(stringr)
+
 # 1) UTILITAIRES DE SPLITTING -------------------------------
 
 # Découpe f en deux parties au premier opérateur de ops au niveau racine,
@@ -334,10 +338,6 @@ fun_map <- list(
   AND    = function(args, noms_cellules = NULL) paste0("(", paste(args, collapse = " & "), ")"), 
   OR = function(args, noms_cellules = NULL) paste0("(", paste(args, collapse = " | "), ")")
 )
-
-vlookup_r <- function(x, table, col) {
-  table[x, col]
-}
 
 convert_formula <- function(form, noms_cellules = list()) {
   # Input validation

--- a/chatbot/modules/parseur_excel/parseur_excel.R
+++ b/chatbot/modules/parseur_excel/parseur_excel.R
@@ -3,9 +3,12 @@
 library(tidyxl)
 library(openxlsx)
 library(dplyr)
+library(stringr)
 
-source("~/work/lereuf/chatbot/modules/parseur_excel/excel_formula_to_R.R")
-source("~/work/lereuf/chatbot/modules/parseur_excel/utils.R")
+# Détermination du répertoire du script pour sourcer les dépendances
+script_dir <- dirname(normalizePath(sys.frame(1)$ofile, mustWork = FALSE))
+source(file.path(script_dir, "excel_formula_to_R.R"))
+source(file.path(script_dir, "utils.R"))
 
 # Fonction principale --------------------------------------------------------
 parse_excel_formulas <- function(path, emit_script = FALSE) {


### PR DESCRIPTION
## Summary
- load `stringr` for Excel parser helpers
- make `parseur_excel` source helper files relative to its own location
- remove unused `vlookup_r` helper definition
- add `stringr` and `dplyr` to dependency installation list

## Testing
- `git status --short`
